### PR TITLE
Fix advanced settlement calculations and data flow

### DIFF
--- a/src/components/bills/settle-all-form.tsx
+++ b/src/components/bills/settle-all-form.tsx
@@ -100,14 +100,16 @@ export function SettleAllForm({ room, currentUserId, onSuccess }: SettleAllFormP
 
     try {
       // Create settlements for each bill with this person
-      // IMPORTANT: When a debtor pays a creditor, the settlement is recorded as
-      // the creditor giving the debtor credit (from_user: creditor, to_user: debtor)
-      // This creates an incoming_settlement for the debtor, reducing their debt
+      // IMPORTANT: When a debtor pays a creditor, we record the debtor as the sender
+      // (from_user) and the creditor as the recipient (to_user). This matches the
+      // way settlements are interpreted everywhere else in the app, ensuring the
+      // debtor's outgoing settlements increase and the creditor's incoming
+      // settlements decrease their balances.
       for (const bill of selectedPersonData.bills) {
         const settlementData: CreateSettlementData = {
           bill_id: bill.bill_id,
-          from_user: selectedPersonData.user_id, // Creditor is giving credit
-          to_user: currentUserId,                 // Debtor is receiving credit
+          from_user: currentUserId,               // Debtor is paying off their balance
+          to_user: selectedPersonData.user_id,    // Creditor is receiving the payment
           amount: bill.amount,
           method: selectedMethod,
           note: note || undefined


### PR DESCRIPTION
## Summary
- ensure the settle-all flow records settlements from the debtor to the creditor to match the rest of the app
- surface advanced bill calculations in bill details and settle-up UI so itemized shares and payments render correctly
- update Supabase service to pull calculation data for advanced bills and adjust bill_calculations when settlements post

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc1823d6d88326af9088b7ab18f2e7