### PR TITLE
Fix advanced settlement calculations and data flow

### DIFF
--- a/src/app/bills/[id]/page.tsx
+++ b/src/app/bills/[id]/page.tsx
@@ -115,6 +115,15 @@ export default function BillDetailsPage() {
   }
 
   const userPosition = getUserPosition()
+  const userCalculation = bill.is_advanced
+    ? bill.calculations?.find(calc => calc.user_id === user.id)
+    : undefined
+  const userShareAmount = userCalculation
+    ? userCalculation.owed_paisa / 100
+    : userPosition?.share_amount ?? 0
+  const userPaidAmount = userCalculation
+    ? userCalculation.covered_paisa / 100
+    : userPosition?.amount_paid ?? 0
   const participants = bill.participants || []
   const payers = bill.payers || []
   const settlements = bill.settlements || []
@@ -276,7 +285,7 @@ export default function BillDetailsPage() {
                         <div className="text-center p-3 bg-blue-50 rounded-lg">
                           <p className="text-sm text-gray-600 mb-1">Your Share</p>
                           <CurrencyDisplay
-                            amount={userPosition.share_amount}
+                            amount={userShareAmount}
                             currency={bill.currency}
                             className="font-semibold text-blue-600"
                           />
@@ -284,7 +293,7 @@ export default function BillDetailsPage() {
                         <div className="text-center p-3 bg-green-50 rounded-lg">
                           <p className="text-sm text-gray-600 mb-1">You Paid</p>
                           <CurrencyDisplay
-                            amount={userPosition.amount_paid}
+                            amount={userPaidAmount}
                             currency={bill.currency}
                             className="font-semibold text-green-600"
                           />

--- a/src/app/bills/[id]/page.tsx
+++ b/src/app/bills/[id]/page.tsx
@@ -18,7 +18,7 @@ import { ResponsiveNav } from '@/components/navigation/responsive-nav'
 import { useAuth } from '@/hooks/use-auth'
 import { useUserRoom } from '@/hooks/use-room-data'
 import { useBillDetails, useUserPosition } from '@/hooks/use-bill-data'
-import { BillStatus } from '@/types'
+import { BillStatus, type AdvanceBillCalculation } from '@/types'
 import { toast } from 'sonner'
 
 export const dynamic = 'force-dynamic'
@@ -127,6 +127,40 @@ export default function BillDetailsPage() {
   const participants = bill.participants || []
   const payers = bill.payers || []
   const settlements = bill.settlements || []
+  const calculations: AdvanceBillCalculation[] = bill.is_advanced
+    ? bill.calculations ?? []
+    : []
+  const calculationMap = new Map<string, AdvanceBillCalculation>()
+  calculations.forEach((calc) => {
+    calculationMap.set(calc.user_id, calc)
+  })
+  const settlementIncomingMap = new Map<string, number>()
+  const settlementOutgoingMap = new Map<string, number>()
+  settlements.forEach((settlement) => {
+    settlementIncomingMap.set(
+      settlement.to_user,
+      (settlementIncomingMap.get(settlement.to_user) ?? 0) + settlement.amount
+    )
+    settlementOutgoingMap.set(
+      settlement.from_user,
+      (settlementOutgoingMap.get(settlement.from_user) ?? 0) + settlement.amount
+    )
+  })
+  const totalAdvancedOwedPaisa = calculations.reduce(
+    (sum, calc) => sum + (Number.isFinite(calc.owed_paisa) ? calc.owed_paisa : 0),
+    0
+  )
+  const totalAdvancedRemainingPaisa = calculations.reduce(
+    (sum, calc) => sum + Math.max(calc.remaining_paisa, 0),
+    0
+  )
+  const hasAdvancedCalculations = bill.is_advanced && calculations.length > 0
+  const totalSettledAmount = hasAdvancedCalculations
+    ? Math.max(0, totalAdvancedOwedPaisa - totalAdvancedRemainingPaisa) / 100
+    : settlements.reduce((sum, s) => sum + s.amount, 0)
+  const outstandingAmount = hasAdvancedCalculations
+    ? Math.max(0, totalAdvancedRemainingPaisa) / 100
+    : undefined
   const StatusIcon = getStatusIcon(bill.status)
 
   // Calculate equal share per participant (fallback for non-advanced bills)
@@ -134,9 +168,7 @@ export default function BillDetailsPage() {
 
   const participantSummary = participants.map(participant => {
     const position = userPositions?.find(p => p.bill_id === billId && p.user_id === participant.user_id)
-    const calculation = bill.is_advanced
-      ? bill.calculations?.find(calc => calc.user_id === participant.user_id)
-      : undefined
+    const calculation = calculationMap.get(participant.user_id)
 
     const shareAmount = calculation
       ? calculation.owed_paisa / 100
@@ -146,20 +178,22 @@ export default function BillDetailsPage() {
       ? calculation.covered_paisa / 100
       : position?.amount_paid ?? (payers.find(p => p.user_id === participant.user_id)?.amount_paid || 0)
 
-    const incomingSettlements = position?.incoming_settlements ?? settlements
-      .filter(s => s.to_user === participant.user_id)
-      .reduce((sum, s) => sum + s.amount, 0)
+    const incomingSettlements = position?.incoming_settlements
+      ?? settlementIncomingMap.get(participant.user_id)
+      ?? 0
 
-    const outgoingSettlements = position?.outgoing_settlements ?? settlements
-      .filter(s => s.from_user === participant.user_id)
-      .reduce((sum, s) => sum + s.amount, 0)
+    const outgoingSettlements = position?.outgoing_settlements
+      ?? settlementOutgoingMap.get(participant.user_id)
+      ?? 0
 
     const netBeforeSettlement = calculation
       ? calculation.net_paisa / 100
       : position?.net_before_settlement ?? (amountPaid - shareAmount)
 
-    const netAfterSettlement = position?.net_after_settlement
-      ?? (netBeforeSettlement + incomingSettlements - outgoingSettlements)
+    const netAfterSettlement = calculation
+      ? calculation.remaining_paisa / 100
+      : position?.net_after_settlement
+        ?? (netBeforeSettlement + incomingSettlements - outgoingSettlements)
 
     return {
       ...participant,
@@ -497,11 +531,22 @@ export default function BillDetailsPage() {
                         <p className="text-gray-600">Total settled</p>
                         <p className="font-medium">
                           <CurrencyDisplay
-                            amount={settlements.reduce((sum, s) => sum + s.amount, 0)}
+                            amount={totalSettledAmount}
                             currency={bill.currency}
                           />
                         </p>
                       </div>
+                      {hasAdvancedCalculations && (
+                        <div>
+                          <p className="text-gray-600">Outstanding</p>
+                          <p className="font-medium">
+                            <CurrencyDisplay
+                              amount={outstandingAmount ?? 0}
+                              currency={bill.currency}
+                            />
+                          </p>
+                        </div>
+                      )}
                     </div>
                   </CardContent>
                 </Card>

--- a/src/components/bills/settle-all-form.tsx
+++ b/src/components/bills/settle-all-form.tsx
@@ -100,14 +100,16 @@ export function SettleAllForm({ room, currentUserId, onSuccess }: SettleAllFormP
 
     try {
       // Create settlements for each bill with this person
-      // IMPORTANT: When a debtor pays a creditor, the settlement is recorded as
-      // the creditor giving the debtor credit (from_user: creditor, to_user: debtor)
-      // This creates an incoming_settlement for the debtor, reducing their debt
+      // IMPORTANT: When a debtor pays a creditor, we record the debtor as the sender
+      // (from_user) and the creditor as the recipient (to_user). This matches the
+      // way settlements are interpreted everywhere else in the app, ensuring the
+      // debtor's outgoing settlements increase and the creditor's incoming
+      // settlements decrease their balances.
       for (const bill of selectedPersonData.bills) {
         const settlementData: CreateSettlementData = {
           bill_id: bill.bill_id,
-          from_user: selectedPersonData.user_id, // Creditor is giving credit
-          to_user: currentUserId,                 // Debtor is receiving credit
+          from_user: currentUserId,               // Debtor is paying off their balance
+          to_user: selectedPersonData.user_id,    // Creditor is receiving the payment
           amount: bill.amount,
           method: selectedMethod,
           note: note || undefined

--- a/src/hooks/use-bill-data.ts
+++ b/src/hooks/use-bill-data.ts
@@ -6,15 +6,17 @@ import { useAuth } from './use-auth'
 import { CreateBillData, CreateSettlementData } from '@/types'
 
 export function useRoomBills(roomId?: string) {
+  const { user } = useAuth()
+
   return useQuery({
-    queryKey: ['room-bills', roomId],
+    queryKey: ['room-bills', roomId, user?.id],
     queryFn: async () => {
-      if (!roomId) return null
-      const { data, error } = await billService.getRoomBills(roomId)
+      if (!roomId || !user?.id) return null
+      const { data, error } = await billService.getRoomBills(roomId, user.id)
       if (error) throw error
       return data
     },
-    enabled: !!roomId,
+    enabled: !!roomId && !!user?.id,
   })
 }
 
@@ -62,32 +64,36 @@ export function useBillDetails(billId?: string) {
 }
 
 export function useRoomStatistics(roomId?: string) {
+  const { user } = useAuth()
+
   return useQuery({
-    queryKey: ['room-statistics', roomId],
+    queryKey: ['room-statistics', roomId, user?.id],
     queryFn: async () => {
-      if (!roomId) return null
-      const { data, error } = await billService.getRoomStatistics(roomId)
+      if (!roomId || !user?.id) return null
+      const { data, error } = await billService.getRoomStatistics(roomId, user.id)
       if (error) throw error
       return data
     },
-    enabled: !!roomId,
+    enabled: !!roomId && !!user?.id,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   })
 }
 
 export function useRecentActivity(roomId?: string, limit: number = 10) {
+  const { user } = useAuth()
+
   return useQuery({
-    queryKey: ['recent-activity', roomId, limit],
+    queryKey: ['recent-activity', roomId, user?.id, limit],
     queryFn: async () => {
-      if (!roomId) return []
-      const { data, error } = await billService.getRecentActivity(roomId, limit)
+      if (!roomId || !user?.id) return []
+      const { data, error } = await billService.getRecentActivity(roomId, user.id, limit)
       if (error) {
         console.warn('Error fetching recent activity:', error)
         return [] // Return empty array on error instead of throwing
       }
       return data || []
     },
-    enabled: !!roomId,
+    enabled: !!roomId && !!user?.id,
     staleTime: 2 * 60 * 1000, // Cache for 2 minutes
   })
 }

--- a/src/lib/bill-calculator.ts
+++ b/src/lib/bill-calculator.ts
@@ -5,7 +5,7 @@
  */
 
 import { Paisa, paisaUtils } from './paisa-utils';
-import { HamiltonRounder, ProportionalTarget } from './hamilton-rounding';
+import { HamiltonRounder } from './hamilton-rounding';
 
 // Core data structures
 export interface BillItem {

--- a/src/lib/settlement-utils.ts
+++ b/src/lib/settlement-utils.ts
@@ -1,0 +1,80 @@
+import { AdvanceBillCalculation, AdvanceBillSuggestedTransfer } from '@/types'
+
+const MIN_SETTLEMENT_PAISA = 100
+
+interface BalanceParticipant {
+  userId: string
+  amount: number
+}
+
+export function deriveSuggestedTransfersFromCalculations(
+  calculations: AdvanceBillCalculation[],
+  billId?: string
+): AdvanceBillSuggestedTransfer[] {
+  if (!calculations || calculations.length === 0) {
+    return []
+  }
+
+  const calculationMap = new Map(calculations.map(calc => [calc.user_id, calc]))
+  const debtors: BalanceParticipant[] = []
+  const creditors: BalanceParticipant[] = []
+
+  for (const calc of calculations) {
+    const remaining = Math.round(Number(calc.remaining_paisa) || 0)
+
+    if (Math.abs(remaining) <= MIN_SETTLEMENT_PAISA) {
+      continue
+    }
+
+    if (remaining < 0) {
+      debtors.push({ userId: calc.user_id, amount: Math.abs(remaining) })
+    } else if (remaining > 0) {
+      creditors.push({ userId: calc.user_id, amount: remaining })
+    }
+  }
+
+  if (debtors.length === 0 || creditors.length === 0) {
+    return []
+  }
+
+  debtors.sort((a, b) => b.amount - a.amount || a.userId.localeCompare(b.userId))
+  creditors.sort((a, b) => b.amount - a.amount || a.userId.localeCompare(b.userId))
+
+  const transfers: AdvanceBillSuggestedTransfer[] = []
+  let debtorIndex = 0
+  let creditorIndex = 0
+
+  while (debtorIndex < debtors.length && creditorIndex < creditors.length) {
+    const debtor = debtors[debtorIndex]
+    const creditor = creditors[creditorIndex]
+
+    const transferAmount = Math.min(debtor.amount, creditor.amount)
+
+    if (transferAmount > MIN_SETTLEMENT_PAISA) {
+      const fromCalc = calculationMap.get(debtor.userId)
+      const toCalc = calculationMap.get(creditor.userId)
+
+      transfers.push({
+        bill_id: billId,
+        from_user_id: debtor.userId,
+        to_user_id: creditor.userId,
+        amount_paisa: transferAmount,
+        from_profile: fromCalc?.profile,
+        to_profile: toCalc?.profile
+      })
+    }
+
+    debtor.amount -= transferAmount
+    creditor.amount -= transferAmount
+
+    if (debtor.amount <= MIN_SETTLEMENT_PAISA) {
+      debtorIndex += 1
+    }
+
+    if (creditor.amount <= MIN_SETTLEMENT_PAISA) {
+      creditorIndex += 1
+    }
+  }
+
+  return transfers
+}

--- a/src/lib/supabase-services.ts
+++ b/src/lib/supabase-services.ts
@@ -13,7 +13,8 @@ import {
   PaymentMethod,
   User,
   CreateAdvanceBillData,
-  AdvanceBillPreview
+  AdvanceBillPreview,
+  AdvanceBillCalculation
 } from '@/types'
 
 export interface RoomService {
@@ -433,6 +434,43 @@ export const billService: BillService = {
         return { data: null, error }
       }
 
+      if (data?.is_advanced) {
+        const { data: calculationsData, error: calculationsError } = await supabase
+          .from('bill_calculations')
+          .select(`
+            bill_id,
+            user_id,
+            owed_paisa,
+            covered_paisa,
+            net_paisa,
+            remaining_paisa,
+            last_updated,
+            profile:profiles!bill_calculations_user_id_fkey (
+              id,
+              full_name,
+              avatar_url
+            )
+          `)
+          .eq('bill_id', billId)
+
+        if (calculationsError) {
+          console.error('Error fetching calculations for bill:', calculationsError)
+        } else if (data) {
+          const calculations = (calculationsData || []).map(calc => ({
+            bill_id: calc.bill_id,
+            user_id: calc.user_id,
+            owed_paisa: Number(calc.owed_paisa) || 0,
+            covered_paisa: Number(calc.covered_paisa) || 0,
+            net_paisa: Number(calc.net_paisa) || 0,
+            remaining_paisa: Number(calc.remaining_paisa) || 0,
+            last_updated: calc.last_updated,
+            profile: Array.isArray(calc.profile) ? calc.profile[0] : calc.profile
+          })) as AdvanceBillCalculation[]
+
+          ;(data as unknown as Bill).calculations = calculations
+        }
+      }
+
       return { data: data as unknown as Bill, error: null }
     } catch (err) {
       console.error('Get bill details error:', err)
@@ -708,6 +746,58 @@ export const billService: BillService = {
         return { data: null, error: settlementError }
       }
 
+      // Update calculated balances to reflect the settlement for advanced bills
+      const settlementAmount = Number(data.amount)
+      const amountPaisa = Math.round(settlementAmount * 100)
+
+      if (!Number.isFinite(amountPaisa)) {
+        console.warn('Skipping calculation update due to invalid settlement amount:', data.amount)
+      } else {
+        const { data: calculationRows, error: calculationFetchError } = await supabase
+          .from('bill_calculations')
+          .select('user_id, remaining_paisa, net_paisa')
+          .eq('bill_id', data.bill_id)
+          .in('user_id', [data.from_user, data.to_user])
+
+        if (calculationFetchError) {
+          console.error('Error fetching bill calculations for settlement update:', calculationFetchError)
+        } else if (calculationRows && calculationRows.length > 0) {
+          const timestamp = new Date().toISOString()
+
+          for (const calcRow of calculationRows) {
+            const currentRemaining = Number(calcRow.remaining_paisa) || 0
+            const currentNet = Number(calcRow.net_paisa) || 0
+            const isPayer = calcRow.user_id === data.from_user
+            const isReceiver = calcRow.user_id === data.to_user
+
+            if (!isPayer && !isReceiver) {
+              continue
+            }
+
+            let updatedRemaining = currentRemaining + (isPayer ? amountPaisa : -amountPaisa)
+
+            if (currentNet < 0) {
+              updatedRemaining = Math.min(updatedRemaining, 0)
+            } else if (currentNet > 0) {
+              updatedRemaining = Math.max(updatedRemaining, 0)
+            }
+
+            const { error: updateError } = await supabase
+              .from('bill_calculations')
+              .update({
+                remaining_paisa: Math.round(updatedRemaining),
+                last_updated: timestamp
+              })
+              .eq('bill_id', data.bill_id)
+              .eq('user_id', calcRow.user_id)
+
+            if (updateError) {
+              console.error('Error updating bill calculations after settlement:', updateError)
+            }
+          }
+        }
+      }
+
       // Update bill status based on settlement completion
       await this.updateBillStatus(data.bill_id)
 
@@ -832,9 +922,10 @@ export const billService: BillService = {
 
   async updateBillStatus(billId: string) {
     try {
-      // Get all user positions for this bill using the database view
+      // Get all user positions for this bill using the unified view so advanced bills
+      // and classic splits share the same settlement calculations
       const { data: userPositions, error: positionsError } = await supabase
-        .from('v_bill_user_position')
+        .from('v_unified_bill_user_position')
         .select('*')
         .eq('bill_id', billId)
 
@@ -851,9 +942,11 @@ export const billService: BillService = {
         return { data: null, error: billError }
       }
 
-      // Check if bill is fully settled using the database view
-      // Anyone with negative net_after_settlement still owes money
-      const hasOutstandingDebts = userPositions?.some(position => position.net_after_settlement < -0.01) || false
+      // Check if bill is fully settled using the unified calculations view.
+      // Any participant with a non-zero net_after_settlement (beyond rounding tolerance)
+      // means there are still outstanding balances on this bill.
+      const hasOutstandingDebts =
+        userPositions?.some(position => Math.abs(Number(position.net_after_settlement) || 0) > 0.01) || false
       const hasSettlements = billDetails.settlements && billDetails.settlements.length > 0
 
       // Determine new status


### PR DESCRIPTION
## Summary
- ensure the settle-all flow records settlements from the debtor to the creditor to match the rest of the app
- surface advanced bill calculations in bill details and settle-up UI so itemized shares and payments render correctly
- update Supabase service to pull calculation data for advanced bills and adjust bill_calculations when settlements post
- derive bill status updates from the unified bill position view so advanced settlements correctly transition bills to settled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc1823d6d88326af9088b7ab18f2e7