### PR TITLE
Normalize simple bill balances and settlement status

### DIFF
--- a/src/components/bills/settle-all-form.tsx
+++ b/src/components/bills/settle-all-form.tsx
@@ -100,14 +100,16 @@ export function SettleAllForm({ room, currentUserId, onSuccess }: SettleAllFormP
 
     try {
       // Create settlements for each bill with this person
-      // IMPORTANT: When a debtor pays a creditor, the settlement is recorded as
-      // the creditor giving the debtor credit (from_user: creditor, to_user: debtor)
-      // This creates an incoming_settlement for the debtor, reducing their debt
+      // IMPORTANT: When a debtor pays a creditor, we record the debtor as the sender
+      // (from_user) and the creditor as the recipient (to_user). This matches the
+      // way settlements are interpreted everywhere else in the app, ensuring the
+      // debtor's outgoing settlements increase and the creditor's incoming
+      // settlements decrease their balances.
       for (const bill of selectedPersonData.bills) {
         const settlementData: CreateSettlementData = {
           bill_id: bill.bill_id,
-          from_user: selectedPersonData.user_id, // Creditor is giving credit
-          to_user: currentUserId,                 // Debtor is receiving credit
+          from_user: currentUserId,               // Debtor is paying off their balance
+          to_user: selectedPersonData.user_id,    // Creditor is receiving the payment
           amount: bill.amount,
           method: selectedMethod,
           note: note || undefined

--- a/src/components/bills/settle-up-form.tsx
+++ b/src/components/bills/settle-up-form.tsx
@@ -13,6 +13,7 @@ import { useCreateSettlement, useUserPosition } from '@/hooks/use-bill-data'
 import { useRoomMembers } from '@/hooks/use-room-data'
 import { Bill, Room, PaymentMethod, CreateSettlementData } from '@/types'
 import { toast } from 'sonner'
+import { deriveSuggestedTransfersFromCalculations } from '@/lib/settlement-utils'
 
 interface SettleUpFormProps {
   bill: Bill
@@ -35,12 +36,29 @@ export function SettleUpForm({ bill, room, currentUserId, onSuccess }: SettleUpF
   // Get current user's position from the database views (this already includes all settlements)
   // net_after_settlement is the final amount: negative = user owes money, positive = user is owed money
   const userPosition = userPositions?.find(p => p.bill_id === bill.id && p.user_id === currentUserId)
-  const userNetDebt = userPosition ? Math.abs(Math.min(0, userPosition.net_after_settlement)) : 0
+  const userCalculation = bill.is_advanced
+    ? bill.calculations?.find(calc => calc.user_id === currentUserId)
+    : undefined
+  const advancedTransfers = bill.is_advanced && bill.calculations?.length
+    ? deriveSuggestedTransfersFromCalculations(bill.calculations, bill.id)
+    : []
+
+  const calculationRemaining = userCalculation ? userCalculation.remaining_paisa / 100 : undefined
+
+  const userNetDebt = userCalculation
+    ? Math.abs(Math.min(0, calculationRemaining ?? 0))
+    : userPosition
+      ? Math.abs(Math.min(0, userPosition.net_after_settlement))
+      : 0
   const maxSettlementAmount = userNetDebt
 
   // For display purposes
-  const userShare = userPosition?.share_amount || 0
-  const userPaid = userPosition?.amount_paid || 0
+  const userShare = userCalculation
+    ? userCalculation.owed_paisa / 100
+    : userPosition?.share_amount || 0
+  const userPaid = userCalculation
+    ? userCalculation.covered_paisa / 100
+    : userPosition?.amount_paid || 0
 
   // Form state
   const [amount, setAmount] = useState(maxSettlementAmount.toString())
@@ -58,19 +76,65 @@ export function SettleUpForm({ bill, room, currentUserId, onSuccess }: SettleUpF
     name: string
     amount: number
   }> => {
-    const recipients: Array<{
-      userId: string
-      name: string
-      amount: number
-    }> = []
     const settlementAmount = parseFloat(amount) || 0
 
-    if (!userPositions || settlementAmount <= 0) return recipients
+    if (settlementAmount <= 0) {
+      return []
+    }
+
+    if (bill.is_advanced && bill.calculations?.length) {
+      const requestedPaisa = Math.max(0, Math.round(settlementAmount * 100))
+      const maxPaisa = Math.max(0, Math.round(maxSettlementAmount * 100))
+      const amountPaisa = Math.min(requestedPaisa, maxPaisa)
+
+      if (amountPaisa <= 0) {
+        return []
+      }
+
+      const userTransfers = advancedTransfers.filter(transfer => transfer.from_user_id === currentUserId)
+
+      if (userTransfers.length === 0) {
+        return []
+      }
+
+      let remainingPaisa = amountPaisa
+      const derivedRecipients: Array<{ userId: string; name: string; amount: number }> = []
+
+      for (const transfer of userTransfers) {
+        if (remainingPaisa <= 0) break
+
+        const transferPaisa = Number(transfer.amount_paisa || 0)
+        const amountToThisCreditor = Math.min(transferPaisa, remainingPaisa)
+
+        if (amountToThisCreditor > 0) {
+          const profile =
+            bill.calculations?.find(calc => calc.user_id === transfer.to_user_id)?.profile ||
+            bill.participants?.find(p => p.user_id === transfer.to_user_id)?.profile ||
+            roomMembers?.find(member => member.user_id === transfer.to_user_id)?.profile
+
+          derivedRecipients.push({
+            userId: transfer.to_user_id,
+            name: profile?.full_name || 'User',
+            amount: amountToThisCreditor / 100
+          })
+
+          remainingPaisa -= amountToThisCreditor
+        }
+      }
+
+      return derivedRecipients
+    }
+
+    if (!userPositions) {
+      return []
+    }
+
+    const recipients: Array<{ userId: string; name: string; amount: number }> = []
 
     // Find creditors (people who are owed money on this bill - positive net_after_settlement)
     const creditors = userPositions
       .filter(p => p.bill_id === bill.id && p.user_id !== currentUserId && p.net_after_settlement > 0)
-      .sort((a, b) => b.net_after_settlement - a.net_after_settlement) // Sort by amount owed (highest first)
+      .sort((a, b) => b.net_after_settlement - a.net_after_settlement)
 
     let remainingSettlement = settlementAmount
 
@@ -104,7 +168,7 @@ export function SettleUpForm({ bill, room, currentUserId, onSuccess }: SettleUpF
       return
     }
 
-    if (settlementAmount > maxSettlementAmount) {
+    if (settlementAmount - maxSettlementAmount > 0.009) {
       toast.error(`Settlement amount cannot exceed ${maxSettlementAmount.toFixed(2)}`)
       return
     }

--- a/src/hooks/use-bill-data.ts
+++ b/src/hooks/use-bill-data.ts
@@ -6,15 +6,17 @@ import { useAuth } from './use-auth'
 import { CreateBillData, CreateSettlementData } from '@/types'
 
 export function useRoomBills(roomId?: string) {
+  const { user } = useAuth()
+
   return useQuery({
-    queryKey: ['room-bills', roomId],
+    queryKey: ['room-bills', roomId, user?.id],
     queryFn: async () => {
-      if (!roomId) return null
-      const { data, error } = await billService.getRoomBills(roomId)
+      if (!roomId || !user?.id) return null
+      const { data, error } = await billService.getRoomBills(roomId, user.id)
       if (error) throw error
       return data
     },
-    enabled: !!roomId,
+    enabled: !!roomId && !!user?.id,
   })
 }
 
@@ -62,32 +64,36 @@ export function useBillDetails(billId?: string) {
 }
 
 export function useRoomStatistics(roomId?: string) {
+  const { user } = useAuth()
+
   return useQuery({
-    queryKey: ['room-statistics', roomId],
+    queryKey: ['room-statistics', roomId, user?.id],
     queryFn: async () => {
-      if (!roomId) return null
-      const { data, error } = await billService.getRoomStatistics(roomId)
+      if (!roomId || !user?.id) return null
+      const { data, error } = await billService.getRoomStatistics(roomId, user.id)
       if (error) throw error
       return data
     },
-    enabled: !!roomId,
+    enabled: !!roomId && !!user?.id,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   })
 }
 
 export function useRecentActivity(roomId?: string, limit: number = 10) {
+  const { user } = useAuth()
+
   return useQuery({
-    queryKey: ['recent-activity', roomId, limit],
+    queryKey: ['recent-activity', roomId, user?.id, limit],
     queryFn: async () => {
-      if (!roomId) return []
-      const { data, error } = await billService.getRecentActivity(roomId, limit)
+      if (!roomId || !user?.id) return []
+      const { data, error } = await billService.getRecentActivity(roomId, user.id, limit)
       if (error) {
         console.warn('Error fetching recent activity:', error)
         return [] // Return empty array on error instead of throwing
       }
       return data || []
     },
-    enabled: !!roomId,
+    enabled: !!roomId && !!user?.id,
     staleTime: 2 * 60 * 1000, // Cache for 2 minutes
   })
 }

--- a/src/lib/bill-calculator.ts
+++ b/src/lib/bill-calculator.ts
@@ -5,7 +5,7 @@
  */
 
 import { Paisa, paisaUtils } from './paisa-utils';
-import { HamiltonRounder, ProportionalTarget } from './hamilton-rounding';
+import { HamiltonRounder } from './hamilton-rounding';
 
 // Core data structures
 export interface BillItem {

--- a/src/lib/settlement-utils.ts
+++ b/src/lib/settlement-utils.ts
@@ -1,0 +1,80 @@
+import { AdvanceBillCalculation, AdvanceBillSuggestedTransfer } from '@/types'
+
+const MIN_SETTLEMENT_PAISA = 100
+
+interface BalanceParticipant {
+  userId: string
+  amount: number
+}
+
+export function deriveSuggestedTransfersFromCalculations(
+  calculations: AdvanceBillCalculation[],
+  billId?: string
+): AdvanceBillSuggestedTransfer[] {
+  if (!calculations || calculations.length === 0) {
+    return []
+  }
+
+  const calculationMap = new Map(calculations.map(calc => [calc.user_id, calc]))
+  const debtors: BalanceParticipant[] = []
+  const creditors: BalanceParticipant[] = []
+
+  for (const calc of calculations) {
+    const remaining = Math.round(Number(calc.remaining_paisa) || 0)
+
+    if (Math.abs(remaining) <= MIN_SETTLEMENT_PAISA) {
+      continue
+    }
+
+    if (remaining < 0) {
+      debtors.push({ userId: calc.user_id, amount: Math.abs(remaining) })
+    } else if (remaining > 0) {
+      creditors.push({ userId: calc.user_id, amount: remaining })
+    }
+  }
+
+  if (debtors.length === 0 || creditors.length === 0) {
+    return []
+  }
+
+  debtors.sort((a, b) => b.amount - a.amount || a.userId.localeCompare(b.userId))
+  creditors.sort((a, b) => b.amount - a.amount || a.userId.localeCompare(b.userId))
+
+  const transfers: AdvanceBillSuggestedTransfer[] = []
+  let debtorIndex = 0
+  let creditorIndex = 0
+
+  while (debtorIndex < debtors.length && creditorIndex < creditors.length) {
+    const debtor = debtors[debtorIndex]
+    const creditor = creditors[creditorIndex]
+
+    const transferAmount = Math.min(debtor.amount, creditor.amount)
+
+    if (transferAmount > MIN_SETTLEMENT_PAISA) {
+      const fromCalc = calculationMap.get(debtor.userId)
+      const toCalc = calculationMap.get(creditor.userId)
+
+      transfers.push({
+        bill_id: billId,
+        from_user_id: debtor.userId,
+        to_user_id: creditor.userId,
+        amount_paisa: transferAmount,
+        from_profile: fromCalc?.profile,
+        to_profile: toCalc?.profile
+      })
+    }
+
+    debtor.amount -= transferAmount
+    creditor.amount -= transferAmount
+
+    if (debtor.amount <= MIN_SETTLEMENT_PAISA) {
+      debtorIndex += 1
+    }
+
+    if (creditor.amount <= MIN_SETTLEMENT_PAISA) {
+      creditorIndex += 1
+    }
+  }
+
+  return transfers
+}


### PR DESCRIPTION
## Summary
- compute per-participant simple bill shares using payer coverage so single-payer bills reflect full debt for the other member
- reuse the normalized simple balances when hydrating user positions, settlement opportunities, and bill status checks to keep amounts consistent with the new share logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc1823d6d88326af9088b7ab18f2e7